### PR TITLE
git module to checkout appropriatelly in individual Packages folders

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name.split('/')[-1] | default(item).split('/')[-1] }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) }}"
+    dest: "{{ sublime_packages_dir }}/xxxxxx"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name.split('/')[-1] | default(item.split('/')[-1]) }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name.split('/')[-1] | default(item) }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+([^/]+)(\\.git)*$','\\1') }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/([^/]+)(\\.git)*$','\\1') }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item.split('/')[-1]) }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)(\.git)*$','\\1'}}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/xxxxxx"
+    dest: "{{ sublime_packages_dir }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)(\.git)*$','\\1') }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)(\\.git)*$','\\1') }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)(\.git)*$','\\1'}}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)(\.git)*$','\\1') }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)\\.*$','\\1') }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)\\.git\\ *$','\\1') }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name.split('/')[-1] | default(item).split('/')[-1] }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name.split('/')[-1] | default(item.split('/')[-1]) }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)\\.git\\ *$','\\1') }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)(\\.git)*\\ *$','\\1') }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)(\\.git)*\\ *$','\\1') }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+([^/]+)(\\.git)*$','\\1') }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name.split('/')[-1] | default(item.split('/')[-1]) }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)(\\.git)*$','\\1') }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/(.+)\\.*$','\\1') }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/([^/]+)(\\.git)*$','\\1') }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) | regex_replace('^.+/([^/.]+)(\\.git)*$','\\1') }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name.split('/')[-1] | default(item.split('/')[-1]) }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item.split('/')[-1]) }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
   git:
     repo: "{{ item.name | default(item) }}"
     version: "{{ item.version | default('master') }}"
-    dest: "{{ sublime_packages_dir }}/{{ item.name.split('/')[-1] | default(item) }}"
+    dest: "{{ sublime_packages_dir }}/{{ item.name | default(item) }}"
     accept_hostkey: "yes"
   with_items: "{{ sublime_packages }}"
   when: sublime_package_control


### PR DESCRIPTION
Currently it appears that the module will try to clone into the Packages folder.
So any checkouts besides the initial repo, fail the ansiible run.

Run with

```
~/.config/sublime-text-3 $  ansible --version
ansible 2.10.3
```

Would end up like:

```
 ~/.../sublime-text-3/Packages $  ll
total 8
drwxr-xr-x 4 vagrant vagrant 4096 Dec 23 11:01 1337-Scheme
drwxr-xr-x 9 vagrant vagrant 4096 Dec 23 11:01 sublimetext-markdown-preview
```